### PR TITLE
replace '\' to '/' on Windows

### DIFF
--- a/path.go
+++ b/path.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package scp
+
+func realPath(path string) string {
+	return path
+}

--- a/path_windows.go
+++ b/path_windows.go
@@ -1,0 +1,12 @@
+// +build windows
+
+package scp
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+func realPath(path string) string {
+	return strings.Replace(path, string(filepath.Separator), "/", -1)
+}

--- a/path_windows_test.go
+++ b/path_windows_test.go
@@ -1,0 +1,18 @@
+package scp
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestRegulatePath(t *testing.T) {
+
+	destinationFromWindows := "/home/ubuntu/destination"
+	cleaned := filepath.Clean(destinationFromWindows) // `\home\ubuntu\destination`
+
+	expected := destinationFromWindows
+
+	if real := realPath(cleaned); real != expected {
+		t.Errorf("%q.realPath() = %q , expected = %q", destinationFromWindows, real, expected)
+	}
+}

--- a/sink.go
+++ b/sink.go
@@ -16,6 +16,7 @@ import (
 // scp.FileInfo, and you can get the access time with fileInfo.(*scp.FileInfo).AccessTime().
 func (s *SCP) Receive(srcFile string, dest io.Writer) (os.FileInfo, error) {
 	var info os.FileInfo
+	srcFile = realPath(filepath.Clean(srcFile))
 	err := runSinkSession(s.client, srcFile, false, "", false, true, func(s *sinkSession) error {
 		var timeHeader timeMsgHeader
 		h, err := s.ReadHeaderOrReply()
@@ -51,7 +52,7 @@ func (s *SCP) Receive(srcFile string, dest io.Writer) (os.FileInfo, error) {
 // the specified name. The time and permission will be set to the same value
 // of the source file.
 func (s *SCP) ReceiveFile(srcFile, destFile string) error {
-	srcFile = filepath.Clean(srcFile)
+	srcFile = realPath(filepath.Clean(srcFile))
 	destFile = filepath.Clean(destFile)
 	fiDest, err := os.Stat(destFile)
 	if err != nil && !os.IsNotExist(err) {
@@ -116,7 +117,7 @@ func copyFileBodyFromRemote(s *sinkSession, localFilename string, timeHeader tim
 // be copied. The time and permission will be set to the same value of the source
 // file or directory.
 func (s *SCP) ReceiveDir(srcDir, destDir string, acceptFn AcceptFunc) error {
-	srcDir = filepath.Clean(srcDir)
+	srcDir = realPath(filepath.Clean(srcDir))
 	destDir = filepath.Clean(destDir)
 	_, err := os.Stat(destDir)
 	if err != nil && !os.IsNotExist(err) {

--- a/source.go
+++ b/source.go
@@ -17,7 +17,7 @@ import (
 // closed, you can pass the result of ioutil.NopCloser(r).
 func (s *SCP) Send(info *FileInfo, r io.ReadCloser, destFile string) error {
 	destFile = filepath.Clean(destFile)
-	destFile = filepath.Dir(destFile)
+	destFile = realPath(filepath.Dir(destFile))
 
 	return runSourceSession(s.client, destFile, false, "", false, true, func(s *sourceSession) error {
 		err := s.WriteFile(info, r)
@@ -32,7 +32,7 @@ func (s *SCP) Send(info *FileInfo, r io.ReadCloser, destFile string) error {
 // The time and permission will be set with the value of the source file.
 func (s *SCP) SendFile(srcFile, destFile string) error {
 	srcFile = filepath.Clean(srcFile)
-	destFile = filepath.Clean(destFile)
+	destFile = realPath(filepath.Clean(destFile))
 
 	return runSourceSession(s.client, destFile, false, "", false, true, func(s *sourceSession) error {
 		osFileInfo, err := os.Stat(srcFile)
@@ -73,7 +73,7 @@ func acceptAny(parentDir string, info os.FileInfo) (bool, error) {
 // The time and permission will be set to the same value of the source file or directory.
 func (s *SCP) SendDir(srcDir, destDir string, acceptFn AcceptFunc) error {
 	srcDir = filepath.Clean(srcDir)
-	destDir = filepath.Clean(destDir)
+	destDir = realPath(filepath.Clean(destDir))
 	if acceptFn == nil {
 		acceptFn = acceptAny
 	}


### PR DESCRIPTION
This PR will fix to path separator problems when used on Windows.

If you run like following on Windows, it will create a file  `\remote\path` on remote.  
But what you need is a directory `/remote/path`.

```golang

scpClient := scp.NewSCP(conn)
scpClient.SendDir("local", "/remote/path", nil) // file `\remote\path` will be created(not a directory) 

```

The cause is using `filepath.Clean` as following:

https://github.com/hnakamur/go-scp/blob/master/source.go#L74
```golang
func (s *SCP) SendDir(srcDir, destDir string, acceptFn AcceptFunc) error {
	srcDir = filepath.Clean(srcDir)
	destDir = filepath.Clean(destDir)
```

On Windows , `filepath.Clean("/remote/path")` return `\remote\path`.
(This value will be used later for starting SCP connection, ex: `scp -rtp '\remote\path'`)  

so, when running on Windows, you should replace `\` to `/` on remote path.
