### PR TITLE
Add support for sudo

### DIFF
--- a/scp.go
+++ b/scp.go
@@ -5,6 +5,9 @@ import "golang.org/x/crypto/ssh"
 // SCP is the type for the SCP client.
 type SCP struct {
 	client *ssh.Client
+	// Alternate scp command. If not set, scp is used. This can be used
+	// to call scp via sudo by setting it to "sudo scp"
+	SCPCommand string
 }
 
 // NewSCP creates the SCP client.

--- a/sink.go
+++ b/sink.go
@@ -17,7 +17,7 @@ import (
 func (s *SCP) Receive(srcFile string, dest io.Writer) (os.FileInfo, error) {
 	var info os.FileInfo
 	srcFile = realPath(filepath.Clean(srcFile))
-	err := runSinkSession(s.client, srcFile, false, "", false, true, func(s *sinkSession) error {
+	err := runSinkSession(s.client, srcFile, false, s.SCPCommand, false, true, func(s *sinkSession) error {
 		var timeHeader timeMsgHeader
 		h, err := s.ReadHeaderOrReply()
 		if err != nil {
@@ -62,7 +62,7 @@ func (s *SCP) ReceiveFile(srcFile, destFile string) error {
 		destFile = filepath.Join(destFile, filepath.Base(srcFile))
 	}
 
-	return runSinkSession(s.client, srcFile, false, "", false, true, func(s *sinkSession) error {
+	return runSinkSession(s.client, srcFile, false, s.SCPCommand, false, true, func(s *sinkSession) error {
 		h, err := s.ReadHeaderOrReply()
 		if err != nil {
 			return fmt.Errorf("failed to read scp message header: err=%s", err)
@@ -136,7 +136,7 @@ func (s *SCP) ReceiveDir(srcDir, destDir string, acceptFn AcceptFunc) error {
 		acceptFn = acceptAny
 	}
 
-	return runSinkSession(s.client, srcDir, false, "", true, true, func(s *sinkSession) error {
+	return runSinkSession(s.client, srcDir, false, s.SCPCommand, true, true, func(s *sinkSession) error {
 		curDir := destDir
 		var timeHeader timeMsgHeader
 		var timeHeaders []timeMsgHeader

--- a/source.go
+++ b/source.go
@@ -19,7 +19,7 @@ func (s *SCP) Send(info *FileInfo, r io.ReadCloser, destFile string) error {
 	destFile = filepath.Clean(destFile)
 	destFile = realPath(filepath.Dir(destFile))
 
-	return runSourceSession(s.client, destFile, false, "", false, true, func(s *sourceSession) error {
+	return runSourceSession(s.client, destFile, false, s.SCPCommand, false, true, func(s *sourceSession) error {
 		err := s.WriteFile(info, r)
 		if err != nil {
 			return fmt.Errorf("failed to copy file: err=%s", err)
@@ -34,7 +34,7 @@ func (s *SCP) SendFile(srcFile, destFile string) error {
 	srcFile = filepath.Clean(srcFile)
 	destFile = realPath(filepath.Clean(destFile))
 
-	return runSourceSession(s.client, destFile, false, "", false, true, func(s *sourceSession) error {
+	return runSourceSession(s.client, destFile, false, s.SCPCommand, false, true, func(s *sourceSession) error {
 		osFileInfo, err := os.Stat(srcFile)
 		if err != nil {
 			return fmt.Errorf("failed to stat source file: err=%s", err)
@@ -78,7 +78,7 @@ func (s *SCP) SendDir(srcDir, destDir string, acceptFn AcceptFunc) error {
 		acceptFn = acceptAny
 	}
 
-	return runSourceSession(s.client, destDir, false, "", true, true, func(s *sourceSession) error {
+	return runSourceSession(s.client, destDir, false, s.SCPCommand, true, true, func(s *sourceSession) error {
 		prevDirSkipped := false
 
 		endDirectories := func(prevDir, dir string) error {


### PR DESCRIPTION
The support was already there, this change simply exposes it. With this change, you can override scp command, and use sudo scp instead.