### PR TITLE
Add go 1.17 style build constraints applied by `go fmt`

### DIFF
--- a/path.go
+++ b/path.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package scp

--- a/path_windows.go
+++ b/path_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package scp

--- a/sink_test.go
+++ b/sink_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package scp_test

--- a/source_test.go
+++ b/source_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package scp_test


### PR DESCRIPTION
This PR just adds the new 1.17 style build constraints (`go:build`). They are automatically applied by `go fmt` when `go.mod` refers a go version >= 1.17.